### PR TITLE
Invoke ruby with --disable-gems:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /man/man?/*.?
 
 /test/fixtures/*.gem
+/*.gem

--- a/exe/_gel-ruby-disable-gems
+++ b/exe/_gel-ruby-disable-gems
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Yes, this shell script is shipped as part of a rubygem. No, that isn't really
+# supported.
+#
+# The core thing we're trying to do here is: we'd reallly like to be
+# able to make the shebang line on exe/gel be '/usr/bin/env ruby --disable-gems'
+# However, that only works on macOS, because most other platforms will only
+# allow a single argument, parsing it as `/usr/bin/env 'ruby --disable-gems'`.
+# SO. We work around that by having it instead execute this script. This script
+# just re-execs ruby with --disable-gems, saving generally around 40-50ms,
+# sometimes more.
+#
+# Both gel and this file are executables of the gem, so they should be in the
+# same directory.
+#
+# If gel is installed in the recommended way via a system package manager (or
+# with `gem install --no-wrappers`), this file will be symlinked, and therefore
+# executed by /bin/sh when invoked. Unfortunately, if it's instead installed by
+# rubygems' default behaviour, it ends up as a ruby binstub, causing this file
+# to be loaded with ruby's Kernel.load, rather than executed by the OS. When
+# that happens, we've lost our opportunity to add --disable-gems, and _also_ we
+# need to tolerate this script being loaded as ruby. So, this is a polyglot
+# script, valid as ruby and also sh.
+#
+# In actuality, this would only ever _really_ be called if 'gel' was executed
+# without a binstub, but the first match on $PATH for this script _was_ a
+# binstub. This will be an uncommon case.
+
+# (see also https://notes.burke.libbey.me/ruby-shell-polyglot)
+
+# In sh, this declares a function called 'print'. The body of this function is
+# kind of valid shell: it would execute a program called '=begin' (which
+# probably doesn't exist. However, it's never called.
+#
+# In ruby, this calls 'print' with no args. print also accepts a block, but
+# (apparently) does nothing with it. We are abusing that here.
+# =begin and =end are a rarely-used feature that bounds a block comment in ruby.
+# So, from ruby's perspective, the block we pass to 'print' is actually empty:
+# =begin to =end are removed.
+print () {
+=begin
+}
+
+### Implementation for Shell ##################
+exec /usr/bin/env ruby --disable-gems "$@"
+###############################################
+exit 1 # exec should exec, but hey, just in case.
+
+# We no longer have to make any attempt to be valid shell, since shells don't
+# pre-parse, and can just guarantee an exit or exec above. This ends the
+# multiline commend, then ends the uncalled no-op block we passed to print.
+=end
+}
+
+### Implementation for Ruby ####################
+# If we're here, we assume we got here via a binstub. We were called like:
+#     ruby _gel-ruby-disable-gems /path/to/gel <gel-args>
+# However, the binstub will have edited our ARGV to just contain <gel-args>.
+load File.expand_path('gel', __dir__)
+################################################

--- a/exe/gel
+++ b/exe/gel
@@ -1,10 +1,13 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env _gel-ruby-disable-gems
 # frozen_string_literal: true
+# -*- ruby -*-
+# vim: set filetype=ruby:
 
 if defined?(::Gem) && !defined?(::Gel)
   # Note there's a similar re-exec in gemlib/gel/stub.rb
 
   exec ::Gem.ruby,
+    "--disable-gems",
     "-I", File.expand_path("../slib", __dir__),
     "--",
     __FILE__,

--- a/gemlib/gel/stub.rb
+++ b/gemlib/gel/stub.rb
@@ -10,6 +10,7 @@ module Gel
     # Note there's a similar re-exec in exe/gel
 
     exec ::Gem.ruby,
+      "--disable-gems",
       "-I", File.expand_path("../slib", __dir__),
       "--",
       File.expand_path("../exe/gel", __dir__),

--- a/test/exe_test.rb
+++ b/test/exe_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+require "tmpdir"
+require "rbconfig"
+
+# Here we're verifying that executing `gel` works regardless of whether the executables
+# are being invoked directly or via binstubs. See the commentary in exe/_gel-ruby-disable-gems
+# for more explanation.
+class ExeTest < Minitest::Test
+  EXE_DIR = File.expand_path('../exe', __dir__)
+
+  def test_exe_without_binstubs
+    err, stat = gel_version_in_path(EXE_DIR)
+    assert stat.success?, "gel version without binstubs failed: #{err}"
+  end
+
+  # This one actually doesn't execute _gel-ruby-disable-gems at all.
+  def test_exe_with_binstubs
+    Dir.mktmpdir do |dir|
+      %w(gel _gel-ruby-disable-gems).each do |exe|
+        File.write(File.join(dir, exe), <<~BINSTUB, perm: 0755)
+          #!#{RbConfig.ruby}
+          ARGV.shift
+          load '#{File.join(EXE_DIR, exe)}'
+        BINSTUB
+      end
+      err, stat = gel_version_in_path(dir)
+      assert stat.success?, "gel version with binstubs failed: #{err}"
+    end
+  end
+
+  def test_gel_ruby_disable_gems_from_binstub
+    Dir.mktmpdir do |dir|
+      exe = "_gel-ruby-disable-gems"
+      File.write(File.join(dir, exe), <<~BINSTUB, perm: 0755)
+        #!#{RbConfig.ruby}
+        ARGV.shift
+        load '#{File.join(EXE_DIR, exe)}'
+      BINSTUB
+      err, stat = gel_version_in_path(dir, bin: '_gel-ruby-disable-gems')
+      assert stat.success?, "welp: #{err}"
+    end
+  end
+
+  private
+
+  def gel_version_in_path(dir, bin: 'gel')
+    _, err, stat = Open3.capture3(
+      # open3 doesn't resolve the initial binary from the provided path,
+      # but we do need to provide it because there's another binary resolved from
+      # that one.
+      { 'PATH' => "#{dir}:#{ENV['PATH']}" }, File.join(dir, bin), 'version',
+    )
+    [err, stat]
+  end
+end


### PR DESCRIPTION
Since we're providing our own rubygems compatibility, we should (or at least can) prevent ruby from loading its built-in version.

In general, this saves approximately 40–60ms of ruby's boot time even once the relevant files are cached in RAM. On my machine, for example:

```
% time ruby  -e ''
... 0.065 total
% time ruby --disable-gems -e ''
... 0.024 total
```