### PR TITLE
Use autoload instead of require_relative

### DIFF
--- a/lib/gel.rb
+++ b/lib/gel.rb
@@ -1,14 +1,75 @@
 # frozen_string_literal: true
 
 module Gel
+  module Autoload
+    def gel_autoload(const_name, relative_path)
+      self.autoload(const_name, File.expand_path(relative_path, __dir__))
+    end
+  end
+
   module Support
+    extend Autoload
+
+    gel_autoload(:CGIEscape, "gel/support/cgi_escape")
+    gel_autoload(:GemPlatform, "gel/support/gem_platform")
+    gel_autoload(:GemRequirement, "gel/support/gem_requirement")
+    gel_autoload(:GemVersion, "gel/support/gem_version")
+    gel_autoload(:SHA512, "gel/support/sha512")
+    gel_autoload(:Tar, "gel/support/tar")
   end
 
   module Vendor
+    extend Autoload
+
+    gel_autoload(:PStore, "../vendor/pstore/lib/pstore")
+    gel_autoload(:RubyDigest, "../vendor/ruby-digest/lib/ruby_digest")
+    gel_autoload(:PubGrub, "../vendor/pub_grub/lib/pub_grub")
   end
 
+  extend Autoload
+
+  gel_autoload(:ReportableError, "gel/error")
+  gel_autoload(:UserError, "gel/error")
+  gel_autoload(:LoadError, "gel/error")
+
+  gel_autoload(:Catalog, "gel/catalog")
+  gel_autoload(:CatalogSet, "gel/catalog_set")
+  gel_autoload(:Command, "gel/command")
+  gel_autoload(:Config, "gel/config")
+  gel_autoload(:DB, "gel/db")
+  gel_autoload(:DirectGem, "gel/direct_gem")
+  gel_autoload(:Environment, "gel/environment")
+  gel_autoload(:Error, "gel/error")
+  gel_autoload(:GemfileParser, "gel/gemfile_parser")
+  gel_autoload(:GemspecParser, "gel/gemspec_parser")
+  gel_autoload(:GitCatalog, "gel/git_catalog")
+  gel_autoload(:GitDepot, "gel/git_depot")
+  gel_autoload(:Httpool, "gel/httpool")
+  gel_autoload(:Installer, "gel/installer")
+  gel_autoload(:LockLoader, "gel/lock_loader")
+  gel_autoload(:LockParser, "gel/lock_parser")
+  gel_autoload(:LockedStore, "gel/locked_store")
+  gel_autoload(:MultiStore, "gel/multi_store")
+  gel_autoload(:NullSolver, "gel/null_solver")
+  gel_autoload(:Package, "gel/package")
+  gel_autoload(:PathCatalog, "gel/path_catalog")
+  gel_autoload(:Pinboard, "gel/pinboard")
+  gel_autoload(:Platform, "gel/platform")
+  gel_autoload(:PubGrub, "gel/pub_grub")
+  gel_autoload(:ResolvedGemSet, "gel/resolved_gem_set")
+  gel_autoload(:Set, "gel/set")
+  gel_autoload(:Stdlib, "gel/stdlib")
+  gel_autoload(:Store, "gel/store")
+  gel_autoload(:StoreCatalog, "gel/store_catalog")
+  gel_autoload(:StoreGem, "gel/store_gem")
+  gel_autoload(:StubSet, "gel/stub_set")
+  gel_autoload(:TailFile, "gel/tail_file")
+  gel_autoload(:Util, "gel/util")
+  gel_autoload(:VERSION, "gel/version")
+  gel_autoload(:VendorCatalog, "gel/vendor_catalog")
+  gel_autoload(:WorkPool, "gel/work_pool")
+
   def self.stub(name)
-    require_relative "gel/command"
     Gel::Command.run(["stub", name, :stub, *ARGV])
   end
 
@@ -18,21 +79,3 @@ module Gel
     File.expand_path("..", __dir__)
   end
 end
-
-require_relative "gel/support/gem_version"
-require_relative "gel/support/gem_requirement"
-
-require_relative "gel/config"
-require_relative "gel/environment"
-require_relative "gel/store"
-require_relative "gel/store_gem"
-require_relative "gel/direct_gem"
-require_relative "gel/locked_store"
-require_relative "gel/multi_store"
-require_relative "gel/error"
-
-require_relative "gel/gemspec_parser"
-require_relative "gel/gemfile_parser"
-require_relative "gel/lock_parser"
-require_relative "gel/lock_loader"
-require_relative "gel/version"

--- a/lib/gel/catalog.rb
+++ b/lib/gel/catalog.rb
@@ -2,11 +2,6 @@
 
 require "uri"
 
-require_relative "httpool"
-require_relative "util"
-require_relative "support/gem_platform"
-require_relative "vendor/ruby_digest"
-
 class Gel::Catalog
   UPDATE_CONCURRENCY = 8
 

--- a/lib/gel/catalog/common.rb
+++ b/lib/gel/catalog/common.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "monitor"
-require_relative "../util"
 
 module Gel::Catalog::Common
   def initialize(uri, uri_identifier, httpool:, work_pool:, cache:)
@@ -66,8 +65,6 @@ module Gel::Catalog::Common
   end
 
   def pinboard
-    require_relative "../pinboard"
-
     @pinboard || @monitor.synchronize do
       @pinboard ||=
         begin

--- a/lib/gel/catalog/compact_index.rb
+++ b/lib/gel/catalog/compact_index.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../set"
-
 class Gel::Catalog::CompactIndex
   include Gel::Catalog::Common
   CACHE_TYPE = "index"

--- a/lib/gel/catalog/dependency_index.rb
+++ b/lib/gel/catalog/dependency_index.rb
@@ -2,9 +2,6 @@
 
 require "zlib"
 
-require_relative "../set"
-require_relative "../support/cgi_escape"
-
 require_relative "marshal_hacks"
 
 class Gel::Catalog::DependencyIndex

--- a/lib/gel/catalog/legacy_index.rb
+++ b/lib/gel/catalog/legacy_index.rb
@@ -2,8 +2,6 @@
 
 require "zlib"
 
-require_relative "../set"
-
 require_relative "marshal_hacks"
 
 class Gel::Catalog::LegacyIndex

--- a/lib/gel/catalog_set.rb
+++ b/lib/gel/catalog_set.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "platform"
-
 class Gel::CatalogSet
   CatalogEntry = Struct.new(:catalog, :name, :version, :info) do
     def gem_version

--- a/lib/gel/command.rb
+++ b/lib/gel/command.rb
@@ -1,9 +1,24 @@
 # frozen_string_literal: true
 
 require_relative "compatibility"
-require_relative "error"
 
 class Gel::Command
+  extend Gel::Autoload
+
+  gel_autoload :Help, "gel/command/help"
+  gel_autoload :Version, "gel/command/version"
+  gel_autoload :Install, "gel/command/install"
+  gel_autoload :InstallGem, "gel/command/install_gem"
+  gel_autoload :Env, "gel/command/env"
+  gel_autoload :Exec, "gel/command/exec"
+  gel_autoload :Lock, "gel/command/lock"
+  gel_autoload :Update, "gel/command/update"
+  gel_autoload :Ruby, "gel/command/ruby"
+  gel_autoload :Stub, "gel/command/stub"
+  gel_autoload :Config, "gel/command/config"
+  gel_autoload :ShellSetup, "gel/command/shell_setup"
+  gel_autoload :Open, "gel/command/open"
+
   def self.run(command_line)
     command_line = command_line.dup
     if command_name = extract_word(command_line)
@@ -107,17 +122,3 @@ class Gel::Command
   # ruby instead of being treated as an internal Gel error
   attr_accessor :reraise
 end
-
-require_relative "command/help"
-require_relative "command/version"
-require_relative "command/install"
-require_relative "command/install_gem"
-require_relative "command/env"
-require_relative "command/exec"
-require_relative "command/lock"
-require_relative "command/update"
-require_relative "command/ruby"
-require_relative "command/stub"
-require_relative "command/config"
-require_relative "command/shell_setup"
-require_relative "command/open"

--- a/lib/gel/command/install_gem.rb
+++ b/lib/gel/command/install_gem.rb
@@ -4,9 +4,6 @@ class Gel::Command::InstallGem < Gel::Command
   def run(command_line)
     gem_name, gem_version = command_line
 
-    require_relative "../catalog"
-    require_relative "../work_pool"
-
     Gel::WorkPool.new(2) do |work_pool|
       catalog = Gel::Catalog.new("https://rubygems.org", work_pool: work_pool)
 

--- a/lib/gel/command/lock.rb
+++ b/lib/gel/command/lock.rb
@@ -24,7 +24,6 @@ class Gel::Command::Lock < Gel::Command
       end
     end
 
-    require_relative "../pub_grub/preference_strategy"
     options[:preference_strategy] = lambda do |gem_set|
       Gel::PubGrub::PreferenceStrategy.new(gem_set, overrides, bump: mode, strict: strict)
     end

--- a/lib/gel/config.rb
+++ b/lib/gel/config.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "util"
-
 ##
 # Reads an optional config file ~/.config/gel/config and injects
 # authorization info from the environment $GEL_AUTH.

--- a/lib/gel/db.rb
+++ b/lib/gel/db.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "util"
-require_relative "vendor/pstore"
-
 require "monitor"
 
 class Gel::DB

--- a/lib/gel/git_catalog.rb
+++ b/lib/gel/git_catalog.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "path_catalog"
-
 class Gel::GitCatalog
   attr_reader :git_depot, :remote, :ref_type, :ref
 

--- a/lib/gel/git_depot.rb
+++ b/lib/gel/git_depot.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "vendor/ruby_digest"
-
 class Gel::GitDepot
   attr_reader :mirror_root
 

--- a/lib/gel/installer.rb
+++ b/lib/gel/installer.rb
@@ -3,11 +3,6 @@
 require "monitor"
 require "net/http"
 
-require_relative "work_pool"
-require_relative "git_depot"
-require_relative "package"
-require_relative "package/installer"
-
 class Gel::Installer
   class SkipCatalog < Exception
   end

--- a/lib/gel/lock_loader.rb
+++ b/lib/gel/lock_loader.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "resolved_gem_set"
-require_relative "git_catalog"
-require_relative "path_catalog"
-
-require_relative "support/gem_platform"
-
 class Gel::LockLoader
   attr_reader :gemfile
 
@@ -24,7 +18,6 @@ class Gel::LockLoader
     locks = {}
 
     if install
-      require_relative "installer"
       installer = Gel::Installer.new(base_store)
     end
 
@@ -80,8 +73,6 @@ class Gel::LockLoader
       else
         unless resolved_gem = resolved_gems.find { |rg| base_store.gem?(name, rg.version, rg.platform) }
           if installer
-            require_relative "catalog"
-
             catalogs = @gem_set.server_catalogs
 
             if resolved_gems.size > 1

--- a/lib/gel/multi_store.rb
+++ b/lib/gel/multi_store.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rbconfig"
-require_relative "stub_set"
 
 class Gel::MultiStore
   VERSION = "#{RbConfig::CONFIG["ruby_version"]}"

--- a/lib/gel/package.rb
+++ b/lib/gel/package.rb
@@ -3,12 +3,12 @@
 require "zlib"
 require "yaml"
 
-require_relative "support/sha512"
-require_relative "support/tar"
-require_relative "vendor/ruby_digest"
-
 module Gel
   class Package
+    extend Gel::Autoload
+    gel_autoload :Installer, "gel/package/installer"
+    gel_autoload :Inspector, "gel/package/inspector"
+
     class Specification
       def initialize(inner)
         @inner = inner

--- a/lib/gel/package/installer.rb
+++ b/lib/gel/package/installer.rb
@@ -4,8 +4,6 @@ require "rbconfig"
 require "tempfile"
 require "shellwords"
 
-require_relative "../util"
-
 class Gel::Package::Installer
   def initialize(store)
     @store = store

--- a/lib/gel/path_catalog.rb
+++ b/lib/gel/path_catalog.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "gemspec_parser"
-
 class Gel::PathCatalog
   attr_reader :path
 

--- a/lib/gel/pinboard.rb
+++ b/lib/gel/pinboard.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "db"
-require_relative "httpool"
-require_relative "tail_file"
-require_relative "work_pool"
-require_relative "vendor/ruby_digest"
-
 # For each URI, this stores:
 #   * the current etag
 #   * an external freshness token

--- a/lib/gel/pub_grub.rb
+++ b/lib/gel/pub_grub.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Gel::PubGrub
+  extend Gel::Autoload
+  gel_autoload :PreferenceStrategy, "gel/pub_grub/preference_strategy"
+  gel_autoload :Package, "gel/pub_grub/package"
+  gel_autoload :Solver, "gel/pub_grub/solver"
+  gel_autoload :Source, "gel/pub_grub/source"
+end

--- a/lib/gel/pub_grub/solver.rb
+++ b/lib/gel/pub_grub/solver.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "source"
-
 class Gel::PubGrub::Solver < Gel::Vendor::PubGrub::VersionSolver
   def self.logger
     ::Gel::Vendor::PubGrub.logger

--- a/lib/gel/pub_grub/source.rb
+++ b/lib/gel/pub_grub/source.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../vendor/pub_grub"
 require_relative "../../../vendor/pub_grub/lib/pub_grub/rubygems"
-
-require_relative "package"
-require_relative "../platform"
 
 module Gel::PubGrub
   class Source < Gel::Vendor::PubGrub::BasicPackageSource

--- a/lib/gel/resolved_gem_set.rb
+++ b/lib/gel/resolved_gem_set.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "set"
-
 class Gel::ResolvedGemSet
   class ResolvedGem
     attr_reader :name, :version, :platform, :deps, :set
@@ -66,11 +64,9 @@ class Gel::ResolvedGemSet
             result.catalog_uris << remote
           end
         when "PATH"
-          require_relative "path_catalog"
           catalog = Gel::PathCatalog.new(body["remote"].first)
         when "GIT"
           ref_type = [:branch, :tag, :ref].find { |t| body[t.to_s] } || :ref
-          require_relative "git_catalog"
           catalog = Gel::GitCatalog.new(git_depot, body["remote"].first, ref_type, body[ref_type.to_s]&.first, body["revision"]&.first)
         end
 
@@ -109,14 +105,10 @@ class Gel::ResolvedGemSet
   def server_catalogs
     @server_catalogs ||=
       begin
-        require_relative "catalog"
-
         remote_catalogs = catalog_uris.map { |uri| Gel::Catalog.new(uri, work_pool: catalog_pool) }
 
         vendor_path = File.expand_path("../vendor/cache", filename)
         if Dir.exist?(vendor_path)
-          require_relative "vendor_catalog"
-
           vendor_catalog = Gel::VendorCatalog.new(vendor_path)
           vendor_catalog.prepare
           [vendor_catalog] + remote_catalogs
@@ -228,7 +220,6 @@ class Gel::ResolvedGemSet
   private
 
   def catalog_pool
-    require_relative "work_pool"
     @catalog_pool ||= Gel::WorkPool.new(8, name: "gel-catalog")
   end
 end

--- a/lib/gel/runtime.rb
+++ b/lib/gel/runtime.rb
@@ -6,7 +6,6 @@ dir = ENV["GEL_STORE"] || "~/.local/gel"
 dir = File.expand_path(dir)
 
 unless Dir.exist?(dir)
-  require_relative "util"
   Gel::Util.mkdir_p(dir)
 end
 

--- a/lib/gel/store.rb
+++ b/lib/gel/store.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "db"
-
 class Gel::Store
   attr_reader :root
   attr_reader :monitor

--- a/lib/gel/store_gem.rb
+++ b/lib/gel/store_gem.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "util"
-
 class Gel::StoreGem
   @compatibility = Hash.new do |h, k|
     Gel::Support::GemRequirement.new(k).satisfied_by?(Gel::Support::GemVersion.new(RUBY_VERSION))

--- a/lib/gel/stub_set.rb
+++ b/lib/gel/stub_set.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "db"
-
 class Gel::StubSet
   attr_reader :root
 

--- a/lib/gel/support/gem_requirement.rb
+++ b/lib/gel/support/gem_requirement.rb
@@ -6,8 +6,6 @@
 # Redistributed under the terms of the MIT license
 #
 
-require_relative "gem_version"
-
 ##
 # A Requirement is a set of one or more version restrictions. It supports a
 # few (<tt>=, !=, >, <, >=, <=, ~></tt>) different restriction operators.

--- a/lib/gel/support/tar.rb
+++ b/lib/gel/support/tar.rb
@@ -1,5 +1,11 @@
 module Gel::Support
   module Tar
+    extend(Gel::Autoload)
+
+    gel_autoload(:TarHeader, "gel/support/tar/tar_header")
+    gel_autoload(:TarReader, "gel/support/tar/tar_reader")
+    gel_autoload(:TarWriter, "gel/support/tar/tar_writer")
+
     class Error < ::RuntimeError; end
 
     class NonSeekableIO < Error; end
@@ -7,7 +13,3 @@ module Gel::Support
     class TarInvalidError < Error; end
   end
 end
-
-require_relative "tar/tar_header"
-require_relative "tar/tar_reader"
-require_relative "tar/tar_writer"

--- a/lib/gel/support/tar/tar_reader.rb
+++ b/lib/gel/support/tar/tar_reader.rb
@@ -9,6 +9,8 @@
 # TarReader reads tar files and allows iteration over their items
 
 class Gel::Support::Tar::TarReader
+  extend Gel::Autoload
+  gel_autoload(:Entry, "gel/support/tar/tar_reader/entry")
 
   include Enumerable
 
@@ -119,5 +121,3 @@ class Gel::Support::Tar::TarReader
   end
 
 end
-
-require_relative "tar_reader/entry"

--- a/lib/gel/tail_file.rb
+++ b/lib/gel/tail_file.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
-require "net/http"
-
-require_relative "httpool"
-
 class Gel::TailFile
   # The number of redirects etc we'll follow before giving up
   MAXIMUM_CHAIN = 8
@@ -36,6 +31,9 @@ class Gel::TailFile
   end
 
   def update(force_reset: false)
+    require "uri"
+    require "net/http"
+
     uri = self.uri
 
     File.open(@filename, "a+b") do |f|

--- a/lib/gel/vendor/pstore.rb
+++ b/lib/gel/vendor/pstore.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "../../../vendor/pstore/lib/pstore"

--- a/lib/gel/vendor/pub_grub.rb
+++ b/lib/gel/vendor/pub_grub.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "../../../vendor/pub_grub/lib/pub_grub"

--- a/lib/gel/vendor/ruby_digest.rb
+++ b/lib/gel/vendor/ruby_digest.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "../../../vendor/ruby-digest/lib/ruby_digest"

--- a/lib/gel/vendor_catalog.rb
+++ b/lib/gel/vendor_catalog.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "package"
-
 class Gel::VendorCatalog
   attr_reader :path
 

--- a/test/gel_test.rb
+++ b/test/gel_test.rb
@@ -144,6 +144,8 @@ class GelTest < Minitest::Test
 
           # If these are present, they're deprecated, so don't touch them
           next if %w(TRUE FALSE NIL Fixnum Bignum Struct::Tms).include?(full_name.join("::"))
+          # If the constant is an autoload that hasn't been forced to load yet, don't force it here.
+          next if scope.autoload?(name)
 
           if ((child = scope.const_get(name)) rescue nil) && child.is_a?(::Module)
             next if parent_modules.include?(child)


### PR DESCRIPTION
This project already did a reasonably good job of deferring loads until necessary, but this improves the situation a bit more. Deferring loading of the various Command classes is relatively significant.

Overall this saves about 5ms on most invocations:

    % hyperfine -w1 'cd gel-require && shadowenv exec -- gel help' 'cd gel-autoload && shadowenv exec -- gel help'
    Benchmark 1: cd gel-require && shadowenv exec -- gel help
      Time (mean ± σ):      33.7 ms ±   2.0 ms    [User: 17.8 ms, System: 10.0 ms]
      Range (min … max):    29.2 ms …  42.1 ms    75 runs

    Benchmark 2: cd gel-autoload && shadowenv exec -- gel help
      Time (mean ± σ):      28.2 ms ±   2.6 ms    [User: 14.2 ms, System: 8.5 ms]
      Range (min … max):    25.2 ms …  46.2 ms    88 runs

    Summary
      'cd gel-autoload && shadowenv exec -- gel help' ran
        1.19 ± 0.13 times faster than 'cd gel-require && shadowenv exec -- gel help'

(both of these branches are running ruby with --disable-gems to get more confounders out of the way)