### PR TITLE
Pass --no-gpg-sign when creating git commit for test

### DIFF
--- a/test/resolve_test.rb
+++ b/test/resolve_test.rb
@@ -562,7 +562,7 @@ GEMSPEC
         export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME" GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
         git -c init.defaultBranch=main init >/dev/null &&
         git add shush.gemspec >/dev/null &&
-        git commit -m initial >/dev/null &&
+        git commit --no-gpg-sign -m initial >/dev/null &&
         git branch my-branch >/dev/null &&
         git rev-parse HEAD`.chomp
       raise "Failed to create git repo" if sha.empty? || !$?.success?


### PR DESCRIPTION
Should have no effect for users without default signing, but not passing it creates a sort of weird experience for users with commit signing on by default.